### PR TITLE
‘Create an Event’ suggestions

### DIFF
--- a/moderator/moderate/forms.py
+++ b/moderator/moderate/forms.py
@@ -61,4 +61,7 @@ class EventForm(forms.ModelForm):
         fields = ['name', 'is_nda']
         widgets = {
             'is_nda': forms.CheckboxInput(),
+        },
+        labels = {
+            'name': 'What\'s the name of the event?'
         }

--- a/moderator/moderate/templates/create_event.jinja
+++ b/moderator/moderate/templates/create_event.jinja
@@ -45,7 +45,7 @@
       <div class="checkbox-nda">
         {{ event_form.is_nda }}
         <label for="{{ event_form.is_nda.id_for_label }}">
-          Is NDA?
+          NDA's Mozillians only
         </label>
       </div>
       <div>

--- a/moderator/moderate/templates/create_event.jinja
+++ b/moderator/moderate/templates/create_event.jinja
@@ -24,7 +24,7 @@
 
 {% block content %}
 
-<h3 class="text-center">Please enter the title of the event</h3>
+<h1 class="text-center h3">Create an Event</h1>
 
 <div class="panel panel-default">
   <div class="panel-body">

--- a/moderator/moderate/templates/create_event.jinja
+++ b/moderator/moderate/templates/create_event.jinja
@@ -38,6 +38,7 @@
       {% csrf_token %}
       {{ event_form.non_field_errors() }}
       <div class="form-group question-text" id="event-input">
+        {{ event_form.name.label_tag() }}
         {{ event_form.name }}
         {{ event_form.errors }}
       </div>


### PR DESCRIPTION
Four suggestions: 

* Seems like the title at the top is the page's main title, so let's make it a `<h1>` 
* Change the title to match the menu item, this way if we decide we need more fields that will still work
* Add a label so that the field has a name for assistive technologies
* Maybe “NDA's Mozillians only” is a good label for the checkbox?