### PR TITLE
Fix typo

### DIFF
--- a/moderator/moderate/templates/create_event.jinja
+++ b/moderator/moderate/templates/create_event.jinja
@@ -44,7 +44,7 @@
         <div class="checkbox-nda">
           {{ event_form.is_nda }}
           <label for="{{ event_form.is_nda.id_for_label }}">
-            NDA's Mozillians only
+            NDA'd Mozillians only
           </label>
         </div>
       {% endif %}


### PR DESCRIPTION
Woops, it should say ‘NDA'd’.