### PR TITLE
add steps for moderator developers to use MAWS to access moderator ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,19 @@ Production Deploy:
 10. (automated): upon merge into master, GHA will do all of the above, _and_ Flux will:
     a. Apply the manifests found in the kubernetes/ directory;
     b. as there will be a change in those manifests for the production application, (our new docker image tag), kubernetes will pull that image down and redeploy the application.
+
+## Moderator Docker Registry Manual Access
+
+In case you want to view or manually push Moderator Docker images to our Production ECR Registry, members of the MozilliansOrg Group `mozilla-moderators-dev` should be able to do the following steps:
+
+```
+# log into that mozilla-moderators-dev group via MAWS
+$ maws -r arn:aws:iam::783633885093:role/moderator-devs
+
+# docker login to that moderator registry
+$ aws ecr get-login-password | docker login --username AWS --password-stdin 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator
+
+# interact with Moderator docker images either via AWS CLI or docker
+$ aws ecr list-images --repository-name moderator
+$ docker pull 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator:379b95c7
+```


### PR DESCRIPTION
JIRA ticket: https://jira.mozilla.com/browse/SE-1703

Related PR(s): https://github.com/mozilla-it/moderator-infra/pull/7

What this PR does: Nothing to the code or infrastructure directly. Instead, it just adds steps for the Moderator Developers to test out moderator ECR access, in case needed while working on this application. It depends on work that is currently being tested in stage above - but this means the instructions added are actionable immediately.