### PR TITLE
Only trigger release CI on the "released" action.

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   release:
-    types: [ published, created, edited ]
+    types: [released]
 
 jobs:
   prepare:


### PR DESCRIPTION
This way, it matched what we look for in the conditionals further down.