### PR TITLE
minimally altering axes configuration as X_Forwarded_For header does seem to be passed

### DIFF
--- a/moderator/settings.py
+++ b/moderator/settings.py
@@ -277,15 +277,13 @@ FROM_NOREPLY = config(
 
 # Django Axes
 AXES_ENABLED = config("AXES_ENABLED", default=True, cast=bool)
-AXES_PROXY_COUNT = 2
 AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP = config(
     "AXES_LOCK_OUT_BY_COMBINATION_USER_AND_IP", default=True, cast=bool
 )
-IPWARE_META_PRECEDENCE_ORDER = (
-    "HTTP_X_FORWARDED_FOR",
-    "IPWARE_META_PRECEDENCE_ORDER",
-    "REMOTE_ADDR",
-)
+AXES_META_PRECEDENCE_ORDER = [
+   'HTTP_X_FORWARDED_FOR',
+   'REMOTE_ADDR',
+]
 
 if DEV and DEBUG:
     EMAIL_LOGGING_REAL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
Everything I've investigated & tuned today seems to indicate that `X_Forwarded_For` header is (now) set correctly and passed by ingress-nginx. Proposing some small Axes configuration changes to stage to test if part of the issue might be the Axes configuration after having worked on the ingress-nginx side.

Can see related PR (last of a string of them) testing ingress-nginx proxy configurations here: https://github.com/mozilla-it/itse-apps-stage-1-infra/pull/87

Can see the logging of X_Forwarded_For header to moderator's gunicorn here:

<img width="1480" alt="image" src="https://user-images.githubusercontent.com/6874040/129113841-fd34dccd-bfde-457d-8329-2ddc666acef1.png">

the last value there is the X_Forwarded_For header logged based off my adding the following to the stage moderator deployment:

```
- /bin/bash
        - -c
        - python manage.py collectstatic --noinput && gunicorn moderator.wsgi:application
          -b 0.0.0.0:8000 --log-file - --access-logfile - --access-logformat '%(h)s
          %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "%({X-Forwarded-For}i)s"'
 ```

The changes in this PR appear to work through my own testing, though I can't tell you if they're just falling back to REMOTE_ADDR (which wouldn't have been used in the original work you did, given IPWARE_META_PRECEDENCE_ORDER looped back to itself before going to REMOTE_ADDR). Curious to get your thoughts.