### PR TITLE
feature: Add date stamp for FluxV2 upgrade

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -20,7 +20,7 @@ jobs:
           export CI_COMMIT_SHORT_SHA=$(git describe --abbrev=7 --always --tags)
           echo $CI_COMMIT_SHORT_SHA;
           if [ ${GITHUB_REF##*/} = "master" ]; then
-            echo "::set-output name=tag::stg-$CI_COMMIT_SHORT_SHA"
+            echo "::set-output name=tag::stg-$CI_COMMIT_SHORT_SHA-$(date +%F.%H%M%S)"
           else
             echo "::set-output name=tag::$CI_COMMIT_SHORT_SHA"
           fi


### PR DESCRIPTION
We will need to migrate our image tag from a `regex` which was available in Flux V1 to Sortable Image Tags https://fluxcd.io/flux/migration/flux-v1-automation-migration/#how-to-use-sortable-image-tags