### PR TITLE
Add label indicating Markdown is allowed in comment

### DIFF
--- a/moderator/moderate/forms.py
+++ b/moderator/moderate/forms.py
@@ -111,7 +111,7 @@ class EventForm(forms.ModelForm):
             msg = "Only members of the NDA group can create NDA events."
             raise forms.ValidationError(msg)
         # Don't allow non-superusers to modify moderation status or moderators
-        if not cdata['moderators']:
+        if not cdata["moderators"]:
             msg = "An event should have at least one moderator."
             raise forms.ValidationError(msg)
 
@@ -127,7 +127,7 @@ class EventForm(forms.ModelForm):
             "moderators",
             "archived",
             "users_can_vote",
-            "event_date"
+            "event_date",
         ]
         widgets = (
             {

--- a/moderator/moderate/templates/questions.jinja
+++ b/moderator/moderate/templates/questions.jinja
@@ -135,6 +135,10 @@
           <h4 class="modal-title">Answer</h4>
         </div>
         <div class="modal-body">
+          <label for="{{ q_form.answer.id_for_label }}">
+            Ask your question below.
+            <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">Markdown supported.</a>
+          </label>
           {{ q_form.answer }}
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
Add a label in the ask question section indicating Markdown is enabled.

This is only for the modal of the reply. The current Question entry isn't a Textarea and doesn't really seem to work out for Markdown. I resolved this, however, in https://github.com/mozilla/mozmoderator/pull/509 . So between these two it should be covered.

forms.py got linted.