### PR TITLE
Updating accessibility of 3 buttons on the Questions template

### DIFF
--- a/moderator/moderate/static/css/main.css
+++ b/moderator/moderate/static/css/main.css
@@ -242,6 +242,10 @@ ul.errorlist {
     margin-left: 15px;
 }
 
+.vote-container .vote .glyphicon {
+    margin-inline-end: 5px;
+}
+
 .edit-container {
     display: inline-block;
     vertical-align: middle;

--- a/moderator/moderate/templates/questions.jinja
+++ b/moderator/moderate/templates/questions.jinja
@@ -108,7 +108,7 @@
       {% endif %}
       {% endif %}
       {% if open and can_answer_question(q, user) %}
-      <button class="btn btn-default btn-sm reply-button" id="{{ q.id }}" aria-label="Answer this question"
+      <button class="btn btn-default btn-sm reply-button" id="{{ q.id }}" title="Answer this question"
         data-toggle="modal" data-target="#AnswerModal">
         reply
       </button>

--- a/moderator/moderate/templates/questions.jinja
+++ b/moderator/moderate/templates/questions.jinja
@@ -95,12 +95,14 @@
       {% endif %}
       {% if open %}
       {% if user_voted(q, user) %}
-      <button class="btn btn-dark btn-sm vote" id="{{ q.id }}" aria-label="Remove the upvote" title="Remove the upvote">
+      <button class="btn btn-dark btn-sm vote" id="{{ q.id }}">
         <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
+        Remove the upvote
       </button>
       {% else %}
-      <button class="btn btn-light btn-sm vote" id="{{ q.id }}" aria-label="Upvote" title="Upvote">
+      <button class="btn btn-light btn-sm vote" id="{{ q.id }}">
         <span class="glyphicon glyphicon-thumbs-up" aria-hidden="true"></span>
+        Upvote
       </button>
       {% endif %}
       {% endif %}


### PR DESCRIPTION
The patch includes the following changes:

1. "Upvote" and "Remove the upvote" buttons are receiving on-screen labels to allow clearly communicate the meaning of each state to sighted users. Currently, relying on an icon alone is shown to be confusing, especially when multiple upvotes were left and the review is needed.
2. Since those buttons receive an on-screen text, their icons got a small margin at the end of the string to allow for more balanced view (spacing between the icon and label)
3. "Reply" button has accessible name that does not include its on-screen name: "Answer to this question", thus we're changing the `aria-label` (that overwrites the name for assistive technology) to `title` (that is shown on-hover and is added to the on-screen name) - it would also serve as a hint to sighted users to clarify the action, i.e. it won't be a direct reply.