### PR TITLE
Use utf8mb4 as pymysql client charset in default env

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -3,7 +3,7 @@ DEBUG=True
 DEV=True
 ANON_ALWAYS=False
 SESSION_COOKIE_SECURE=False
-DATABASE_URL='mysql://moderator:moderator@mariadb:3306/moderator'
+DATABASE_URL='mysql://moderator:moderator@mariadb:3306/moderator?charset=utf8mb4'
 SITE_URL='http://127.0.0.1:8000'
 ALLOWED_HOSTS=*
 ENABLE_DEV_LOGIN=True


### PR DESCRIPTION
When investigating #341 using the boilerplate `.env-dist` connection strings locally, it shows that the defaults used for connecting to mariadb would trigger `DataError` ("Incorrect string value") exception with certain content posted:

<img width="1036" alt="Screenshot 2025-05-02 at 16 34 05" src="https://github.com/user-attachments/assets/6f8fd929-e483-41c5-b682-2c7e010fd794" />

It turns out I was able to post either Latin-ext or non-Latin Unicode scripts successfully, or use e.g. a heart ❤️ emoji — however the app would crash if I tried anything more astral as facepalming 🤦 monkeys 🙈 et al. …

_(passed:)_
![Screenshot 2025-05-02 at 17 16 02](https://github.com/user-attachments/assets/0b445244-cc95-4796-a325-59a355f7241d)

_(crashed:)_
![Screenshot 2025-05-02 at 16 34 24 Large](https://github.com/user-attachments/assets/e041a226-a584-4f69-ad5e-5511bb6fe95a)

The default `charset=utf8` used is actually `utf8mb3`, not full `utf8mb4`, so that effectively rules out emoji etc.:/ — TL;DR: https://forum.djangoproject.com/t/ticket-18392-and-mysql-utf8mb4/34916

This won't magically fix production tables and collation for mb4 storage, but is currently needed for the Django versions used to at least stop crashing on such content locally.

Passing this arg to `dj_database_url` here expands it into OPTIONS correctly, as can be seen below running this tweak locally and being able to insert emoji: … ;)

![Screenshot 2025-05-02 at 17 16 06](https://github.com/user-attachments/assets/b70f851c-1ee2-4de3-a5c5-9dffe13f5270)