### PR TITLE
Move to Python 3.11.12 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.12 AS base
+FROM python:3.11 AS base
 
 ENV POETRY_VERSION=1.8.2 \
   POETRY_VIRTUALENVS_IN_PROJECT=true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ EXPOSE $PORT
 CMD ["./bin/run-dev.sh"]
 
 # Production image
-FROM python:3.11.12-slim AS prod
+FROM python:3.11-slim AS prod
 
 ARG UID=10001
 ARG GID=10001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7 AS base
+FROM python:3.11.12 AS base
 
 ENV POETRY_VERSION=1.8.2 \
   POETRY_VIRTUALENVS_IN_PROJECT=true \
@@ -50,7 +50,7 @@ EXPOSE $PORT
 CMD ["./bin/run-dev.sh"]
 
 # Production image
-FROM python:3.11.7-slim AS prod
+FROM python:3.11.12-slim AS prod
 
 ARG UID=10001
 ARG GID=10001


### PR DESCRIPTION
I've been running this locally together with #522 (4.2.x) for some time and don't see anything obviously wrong — reckon both bumps would add some peace of mind given their long support cycle.

Bugfixes stopped at 3.11.9 (2024-04-02) and it's only security updates since so should be uneventful.

BTW the image is slightly smaller in size, and has less vulns:
> ![Screenshot 2025-05-19 at 19 44 23](https://github.com/user-attachments/assets/2faebd96-8e45-4da5-a440-42eaa52bf16c)