### PR TITLE
Update staff groups for moderator

### DIFF
--- a/moderator/settings.py
+++ b/moderator/settings.py
@@ -261,11 +261,10 @@ ALLOWED_LOGIN_GROUPS = [
     "team_moco",
     "team_mofo",
     "team_mozillaonline",
-    "team_pocket",
+    "team_mozorg",
     "team_mzla",
     "team_mzvc",
     "team_mzai",
-    "hris_is_staff",
     "mozilliansorg_nda",
     "mozilliansorg_contingentworkernda",
 ]


### PR DESCRIPTION
team_mozorg is a new entity as of 2026.
team_pocket became a manual group of moco people who were doing pocket things.  Anyone in this group is better covered by other team_ groups. hris_is_staff is a relic of pre-2020, history lesson in https://bugzilla.mozilla.org/show_bug.cgi?id=1637172 - but should not be relied upon.